### PR TITLE
Move default stack pointer location.

### DIFF
--- a/memory.x
+++ b/memory.x
@@ -7,6 +7,14 @@ MEMORY {
      * as scratch space during the skboot calls.
      */
     RAM (rw): ORIGIN = 0x30004000, LENGTH = 4K
+    /*
+     * Stack is shifted hundreds of kiB away to try to avoid stack clash,
+     * since the ROM's RAM usage means we can't simply have stack grow toward
+     * unmapped address space.
+     *
+     * The -32 there is to avoid the transient override section.
+     */
+    STACK (rw): ORIGIN = 0x30010000, LENGTH = 192K - 32
 
     /*
      * A/B images start at 64kiB for compatibility with the old bootloader's
@@ -41,6 +49,13 @@ MEMORY {
  */
 __start_of_ram = ORIGIN(RAM);
 __end_of_ram = ORIGIN(RAM) + LENGTH(RAM);
+
+SECTIONS {
+    .stack_placeholder ORIGIN(STACK) (NOLOAD): ALIGN(8) {
+        . += LENGTH(STACK);
+        _stack_start = .;
+    } > STACK
+} INSERT BEFORE .uninit
 
 SECTIONS {
     .rom_table ORIGIN(ROM_TABLE) (NOLOAD): {


### PR DESCRIPTION
We had inherited cortex-m-rt's default setting, placing it at the end of RAM. Our RAM definition in the linker, however, is small, and that put the stack pointer near bss, making clash more likely.

I have moved it just under 192 kiB away, because my usual trick of having the stack grow into unmapped address space isn't available in this context, due to the ROM using the base of SRAM for Important Things.

FWIW, this moves the initial stack pointer to `0x3003_ffe0` which is just below the end of SRAM3, since I'm not sure whether the ROM uses the PowerQuad accelerator, and if it does then SRAM4 is spoken for.