### PR TITLE
Fixes for both transient override bugs.

### DIFF
--- a/src/bin/bootleby.rs
+++ b/src/bin/bootleby.rs
@@ -50,12 +50,15 @@ fn main() -> ! {
     let a_ok = bootleby::verify_image(&p.FLASH, SlotId::A);
     let b_ok = bootleby::verify_image(&p.FLASH, SlotId::B);
 
+    // Run the choice/override mechanism whether or not we have two good images,
+    // because it has side effects on the transient override state.
+    let choice = check_for_override(&p.GPIO);
+
     let (header, contents) = match (a_ok, b_ok) {
         (Some(img), None) => img,
         (None, Some(img)) => img,
         (Some(img_a), Some(img_b)) => {
             // Defer to the choice/override mechanism if both images are good.
-            let choice = check_for_override(&p.GPIO);
             match choice {
                 SlotId::A => img_a,
                 SlotId::B => img_b,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,30 +447,17 @@ pub const PREFER_SLOT_B: [u8; 32] = hex!(
 /// Inspects the contents of `buffer` to see if it contains one of the special
 /// byte sequences for overriding boot preference.
 ///
-/// If it _does,_ it will be cleared and the bottom bit of the first byte set to
-/// reflect the choice, which is why this requires a `&mut`. If it contains
-/// other arbitrary data, it will be preserved. This is arguably an odd division
-/// of responsibilities, but it makes our standard use case -- processing a boot
-/// command _exactly once_ -- far harder to screw up.
-///
 /// This function doesn't implicitly access the `TRANSIENT_OVERRIDE` buffer
 /// because, to do so safely, we need to know about the processor's situation
 /// and interrupt handlers. You'll have to do it when you call.
-pub fn check_transient_override(buffer: &mut [u8; 32]) -> Option<SlotId> {
-    let choice = if buffer == &PREFER_SLOT_A {
+pub fn check_transient_override(buffer: &[u8; 32]) -> Option<SlotId> {
+    if buffer == &PREFER_SLOT_A {
         Some(SlotId::A)
     } else if buffer == &PREFER_SLOT_B {
         Some(SlotId::B)
     } else {
         None
-    };
-
-    if let Some(slot) = choice {
-        buffer.fill(0);
-        buffer[0] = if slot == SlotId::A { 0 } else { 1 };
     }
-
-    choice
 }
 
 /// Reads the committed pages (ping-pong pages) of the CFPA, determines which

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,10 +447,11 @@ pub const PREFER_SLOT_B: [u8; 32] = hex!(
 /// Inspects the contents of `buffer` to see if it contains one of the special
 /// byte sequences for overriding boot preference.
 ///
-/// If it _does,_ it will be cleared, which is why this requires a `&mut`. If it
-/// contains other arbitrary data, it will be preserved. This is arguably an odd
-/// division of responsibilities, but it makes our standard use case --
-/// processing a boot command _exactly once_ -- far harder to screw up.
+/// If it _does,_ it will be cleared and the bottom bit of the first byte set to
+/// reflect the choice, which is why this requires a `&mut`. If it contains
+/// other arbitrary data, it will be preserved. This is arguably an odd division
+/// of responsibilities, but it makes our standard use case -- processing a boot
+/// command _exactly once_ -- far harder to screw up.
 ///
 /// This function doesn't implicitly access the `TRANSIENT_OVERRIDE` buffer
 /// because, to do so safely, we need to know about the processor's situation
@@ -464,8 +465,9 @@ pub fn check_transient_override(buffer: &mut [u8; 32]) -> Option<SlotId> {
         None
     };
 
-    if choice.is_some() {
+    if let Some(slot) = choice {
         buffer.fill(0);
+        buffer[0] = if slot == SlotId::A { 0 } else { 1 };
     }
 
     choice


### PR DESCRIPTION
This fixes #27 by moving the transient override check to an unconditional codepath, and fixes #28 by recording what transient override was observed (in addition to the fact that one _was_ observed, which already worked).

For more details see the individual commit messages.