### PR TITLE
rot_carrier: fix floating override buttons

### DIFF
--- a/src/bsp/rot_carrier.rs
+++ b/src/bsp/rot_carrier.rs
@@ -26,9 +26,17 @@ pub struct Board;
 
 impl Bsp for Board {
     fn configure(iocon: &lpc55_pac::IOCON, _gpio: &lpc55_pac::GPIO) {
-        // Make our override buttons digital inputs.
-        iocon.pio0_2.modify(|_, w| w.digimode().set_bit());
-        iocon.pio0_6.modify(|_, w| w.digimode().set_bit());
+        // Make our override buttons digital inputs with pulldowns.
+        iocon.pio0_2.modify(|_, w| {
+            w.digimode().set_bit();
+            w.mode().pull_down();
+            w
+        });
+        iocon.pio0_6.modify(|_, w| {
+            w.digimode().set_bit();
+            w.mode().pull_down();
+            w
+        });
     }
 
     fn indicate_fault(gpio: &lpc55_pac::gpio::RegisterBlock) {


### PR DESCRIPTION
If you have the Digilent "four pushbuttons" PMOD plugged into the Aux port, it gives you the ability to override boot selection.

However, if you _don't_ have it plugged in, the pins are floating, and the boot gets overridden more-or-less at random. That's obviously not ideal, so this change turns on pulldown resistors to ensure that the floating pins are in a predictable (and not-overridey) state.