### PR TITLE
Add Image Header to bootleby

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,8 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
 fn main() {
     let mut target_board: Option<String> = None;
 
@@ -20,6 +25,43 @@ fn main() {
     if target_board.is_none() {
         panic!("missing target-board-* feature");
     }
+
+    // Could add a feature to make this optional
+    gen_linker_script();
+}
+
+fn gen_linker_script() {
+    // TODO Pull out into another crate?
+    #[repr(C)]
+    struct ImageHeader {
+        magic: u32,
+        total_image_len: u32,
+        _pad: [u32; 16], // previous location of SAU entries
+        version: u32,
+        epoch: u32,
+    }
+
+    println!("cargo:rerun-if-changed=link.x.in");
+    let base = std::fs::read("link.x.in").unwrap();
+
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let mut linker_script = File::create(out.join("link.x")).unwrap();
+
+    writeln!(
+        linker_script,
+        "_HUBRIS_IMAGE_HEADER_ALIGN = {:#x};",
+        std::mem::align_of::<ImageHeader>()
+    )
+    .unwrap();
+    writeln!(
+        linker_script,
+        "_HUBRIS_IMAGE_HEADER_SIZE = {:#x};",
+        std::mem::size_of::<ImageHeader>()
+    )
+    .unwrap();
+
+    linker_script.write_all(&base).unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
 }
 
 fn show_feature(envvar: &str) -> String {

--- a/link.x.in
+++ b/link.x.in
@@ -1,0 +1,284 @@
+/* Provides information about the memory layout of the device */
+/* This will be provided by the user (see `memory.x`) or by a Board Support Crate */
+INCLUDE memory.x
+
+/* # Entry point = reset vector */
+ENTRY(Reset);
+EXTERN(__RESET_VECTOR); /* depends on the `Reset` symbol */
+
+/* # Exception vectors */
+/* This is effectively weak aliasing at the linker level */
+/* The user can override any of these aliases by defining the corresponding symbol themselves (cf.
+   the `exception!` macro) */
+EXTERN(__EXCEPTIONS); /* depends on all the these PROVIDED symbols */
+
+EXTERN(DefaultHandler);
+
+PROVIDE(NonMaskableInt = DefaultHandler);
+EXTERN(HardFaultTrampoline);
+PROVIDE(MemoryManagement = DefaultHandler);
+PROVIDE(BusFault = DefaultHandler);
+PROVIDE(UsageFault = DefaultHandler);
+PROVIDE(SecureFault = DefaultHandler);
+PROVIDE(SVCall = DefaultHandler);
+PROVIDE(DebugMonitor = DefaultHandler);
+PROVIDE(PendSV = DefaultHandler);
+PROVIDE(SysTick = DefaultHandler);
+
+PROVIDE(DefaultHandler = DefaultHandler_);
+PROVIDE(HardFault = HardFault_);
+
+/* # Interrupt vectors */
+EXTERN(__INTERRUPTS); /* `static` variable similar to `__EXCEPTIONS` */
+
+/* # Pre-initialization function */
+/* If the user overrides this using the `pre_init!` macro or by creating a `__pre_init` function,
+   then the function this points to will be called before the RAM is initialized. */
+PROVIDE(__pre_init = DefaultPreInit);
+
+/* # Sections */
+SECTIONS
+{
+  PROVIDE(_stack_start = ORIGIN(RAM) + LENGTH(RAM));
+
+  /* ## Sections in FLASH */
+  /* ### Vector table */
+  .vector_table ORIGIN(FLASH) :
+  {
+    __start_vector = .;
+    /* Initial Stack Pointer (SP) value */
+    LONG(_stack_start);
+
+    /* Reset vector */
+    KEEP(*(.vector_table.reset_vector)); /* this is the `__RESET_VECTOR` symbol */
+    __reset_vector = .;
+
+    /* Exceptions */
+    KEEP(*(.vector_table.exceptions)); /* this is the `__EXCEPTIONS` symbol */
+    __eexceptions = .;
+
+    /* Device specific interrupts */
+    KEEP(*(.vector_table.interrupts)); /* this is the `__INTERRUPTS` symbol */
+  } > FLASH
+
+  __vector_size = SIZEOF(.vector_table);
+  /* Header containing data needed by the bootloader.  We specify
+     _HUBRIS_IMAGE_HEADER_SIZE and _HUBRIS_IMAGE_HEADER_ALIGN in memory.x at
+     build time, then reserve enough space for the header here in the linker
+     script.
+   */
+  .header :
+  {
+    ASSERT(. == ALIGN(_HUBRIS_IMAGE_HEADER_ALIGN), "error: header alignment is invalid");
+    HEADER = .;
+    . = . + _HUBRIS_IMAGE_HEADER_SIZE;
+  } > FLASH
+
+  /* Explicitly place text at vector table + size of header, deliberately ignoring
+     section alignment. This is important because the bootloader assumes that the header
+     immediately follows the vector table; if something changes to cause that to not
+     be true, this expression will cause the text and header sections to overlap, causing
+     a difficult to understand linker failure, which will hopefully be somewhat improved
+     by this comment.
+  */
+  PROVIDE(_stext = ADDR(.vector_table) + SIZEOF(.vector_table) + SIZEOF(.header));
+
+  /* ### .text */
+  .text _stext :
+  {
+    __stext = .;
+    /* place these 2 close to each other or the `b` instruction will fail to link */
+    *(.PreResetTrampoline);
+    *(.Reset);
+
+    *(.text .text.*);
+
+    /* The HardFaultTrampoline uses the `b` instruction to enter `HardFault`,
+       so must be placed close to it. */
+    *(.HardFaultTrampoline);
+    *(.HardFault.*);
+    . = ALIGN(4);
+    __etext = .;
+  } > FLASH
+
+  /* ### .rodata */
+  .rodata __etext : ALIGN(4)
+  {
+    __srodata = .;
+    *(.rodata .rodata.*);
+    /* We move this into a special section so we can ensure it is always
+       included in the build */
+    KEEP(*(.hubris_id));
+    /* 4-byte align the end (VMA) of this section.
+       This is required by LLD to ensure the LMA of the following .data
+       section will have the correct alignment. */
+    . = ALIGN(4);
+    __erodata = .;
+  } > FLASH
+
+  /* ## Sections in RAM */
+  /* ### .data */
+  .data : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __sdata = .;
+    *(.data .data.*);
+    . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
+  } > RAM AT>FLASH
+  /* Allow sections from user `memory.x` injected using `INSERT AFTER .data` to
+   * use the .data loading mechanism by pushing __edata. Note: do not change
+   * output region or load region in those user sections! */
+  . = ALIGN(4);
+  __edata = .;
+
+  /* LMA of .data */
+  __sidata = LOADADDR(.data);
+
+  /* ### .gnu.sgstubs
+     This section contains the TrustZone-M veneers put there by the Arm GNU linker. */
+  /* Security Attribution Unit blocks must be 32 bytes aligned. */
+  /* Note that this pads the FLASH usage to 32 byte alignment. */
+  .gnu.sgstubs : {
+    . = ALIGN(32);
+    __veneer_base = .;
+    *(.gnu.sgstubs*)
+    . = ALIGN(32);
+    __veneer_limit = .;
+  } > FLASH
+
+   /*
+    * Add a 256 byte caboose region: 4 for the caboose marker, 4 for the
+    * caboose size and the other 248 bytes for caboosey things
+    */
+  .caboose : ALIGN(4) {
+    LONG(0xcab0005e);
+    . += 248;
+    LONG(256);
+  } > FLASH =0xffffffff
+
+  /* ### .bss */
+  .bss (NOLOAD) : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __sbss = .;
+    *(.bss .bss.*);
+    *(COMMON); /* Uninitialized C statics */
+    . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
+  } > RAM
+  /* Allow sections from user `memory.x` injected using `INSERT AFTER .bss` to
+   * use the .bss zeroing mechanism by pushing __ebss. Note: do not change
+   * output region or load region in those user sections! */
+  . = ALIGN(4);
+  __ebss = .;
+
+  /* ### .uninit */
+  .uninit (NOLOAD) : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __suninit = .;
+    *(.uninit .uninit.*);
+    . = ALIGN(4);
+    __euninit = .;
+  } > RAM
+
+  /* Place the heap right after `.uninit` in RAM */
+  PROVIDE(__sheap = __euninit);
+
+  /* ## .got */
+  /* Dynamic relocations are unsupported. This section is only used to detect relocatable code in
+     the input files and raise an error if relocatable code is found */
+  .got (NOLOAD) :
+  {
+    KEEP(*(.got .got.*));
+  }
+
+  /* ## Discarded sections */
+  /DISCARD/ :
+  {
+    /* Unused exception related info that only wastes space */
+    *(.ARM.exidx);
+    *(.ARM.exidx.*);
+    *(.ARM.extab.*);
+  }
+}
+
+INCLUDE device.x
+
+/* Do not exceed this mark in the error messages below                                    | */
+/* # Alignment checks */
+ASSERT(ORIGIN(FLASH) % 4 == 0, "
+ERROR(cortex-m-rt): the start of the FLASH region must be 4-byte aligned");
+
+ASSERT(ORIGIN(RAM) % 4 == 0, "
+ERROR(cortex-m-rt): the start of the RAM region must be 4-byte aligned");
+
+ASSERT(__sdata % 4 == 0 && __edata % 4 == 0, "
+BUG(cortex-m-rt): .data is not 4-byte aligned");
+
+ASSERT(__sidata % 4 == 0, "
+BUG(cortex-m-rt): the LMA of .data is not 4-byte aligned");
+
+ASSERT(__sbss % 4 == 0 && __ebss % 4 == 0, "
+BUG(cortex-m-rt): .bss is not 4-byte aligned");
+
+ASSERT(__sheap % 4 == 0, "
+BUG(cortex-m-rt): start of .heap is not 4-byte aligned");
+
+/* # Position checks */
+
+/* ## .vector_table */
+ASSERT(__reset_vector == ADDR(.vector_table) + 0x8, "
+BUG(cortex-m-rt): the reset vector is missing");
+
+ASSERT(__eexceptions == ADDR(.vector_table) + 0x40, "
+BUG(cortex-m-rt): the exception vectors are missing");
+
+ASSERT(SIZEOF(.vector_table) > 0x40, "
+ERROR(cortex-m-rt): The interrupt vectors are missing.
+Possible solutions, from most likely to less likely:
+- Link to a svd2rust generated device crate
+- Check that you actually use the device/hal/bsp crate in your code
+- Disable the 'device' feature of cortex-m-rt to build a generic application (a dependency
+may be enabling it)
+- Supply the interrupt handlers yourself. Check the documentation for details.");
+
+/* ## .text */
+ASSERT(ADDR(.vector_table) + SIZEOF(.vector_table) <= _stext, "
+ERROR(cortex-m-rt): The .text section can't be placed inside the .vector_table section
+Set _stext to an address greater than the end of .vector_table (See output of `nm`)");
+
+ASSERT(_stext + SIZEOF(.text) < ORIGIN(FLASH) + LENGTH(FLASH), "
+ERROR(cortex-m-rt): The .text section must be placed inside the FLASH memory.
+Set _stext to an address smaller than 'ORIGIN(FLASH) + LENGTH(FLASH)'");
+
+/* # Other checks */
+ASSERT(SIZEOF(.got) == 0, "
+ERROR(cortex-m-rt): .got section detected in the input object files
+Dynamic relocations are not supported. If you are linking to C code compiled using
+the 'cc' crate then modify your build script to compile the C code _without_
+the -fPIC flag. See the documentation of the `cc::Build.pic` method for details.");
+
+  /* So let's talk about vector table alignment:
+   * ARMv8m section B3.30
+   * In a PE with a configurable vector table base, the vector table is naturally-aligned to a power of two, with an
+   * alignment value that is:
+   *  - A minimum of 128 bytes.
+   *  - Greater than or equal to (Number of Exceptions supported x4)
+   * ARMv7m section B1.5.3
+   * The Vector table must be naturally aligned to a power of two whose alignment value is greater than or equal to
+   * (Number of Exceptions supported x 4), with a minimum alignmentof 128 bytes.
+   *
+   * Annoyingly this means that vector table alignment is device specific.
+   * This is also a nice catch-22: we need to know the size of the vector
+   * table to calculate the alignment but we need to know the alignment
+   * before we know the size.
+   *
+   * The best we can do right now is use a specified alignment and
+   * indicate if it is wrong
+   */
+ASSERT(ADDR(.vector_table) % (1 << LOG2CEIL(SIZEOF(.vector_table))) == 0, "
+Vector table alignment too small for number of exception entires. Increase
+the alignment to the next power of two");
+
+
+/* Do not exceed this mark in the error messages above                                    | */


### PR DESCRIPTION
We want to be able to add a caboose post build to store some meta information. This requires an image header that lives right after the vector table. The easiest way to add this is with a custom linker script.