### PR TITLE
Fix off by one when checking for programmed pages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@ pub fn verify_image(
     // so `image_length` is significantly smaller than `u32::MAX`. So, we
     // override the overflow check.
     let image_length_fwords =
-        header.image_length.wrapping_add(BYTES_PER_FWORD_U32 + 1) / BYTES_PER_FWORD_U32;
+        header.image_length.wrapping_add(BYTES_PER_FWORD_U32 - 1) / BYTES_PER_FWORD_U32;
 
     // Verify that every. single. page. of the image is readable, because the
     // ROM doesn't do this despite NXP suggesting it in their app notes.


### PR DESCRIPTION
We should be adding `BYTES_PER_FWORD_U32 - 1`. This means the calculation is incorrect for lengths that are divisible by 0 or 15. and we'll be checking one extra word. This typically goes unnoticed since we programm full pages. If the image length is exactly a page size we will incorrectly expect one extra programmed page.